### PR TITLE
Console.log doesn't support multiple arguments on Android

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -47,7 +47,7 @@ export class Ionic2PushApp {
     const pushObject: PushObject = this.push.init(options);
 
     pushObject.on('registration').subscribe((data: any) => {
-      console.log("device token ->", data.registrationId);
+      console.log("device token -> " + data.registrationId);
       //TODO - send device token to server
     });
 


### PR DESCRIPTION
See:
https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-console/#android-quirks
https://bugs.chromium.org/p/chromium/issues/detail?id=481013
http://stackoverflow.com/questions/29844121/console-message-captured-by-onconsolemessage-is-incomplete